### PR TITLE
Fix Southerm/Northerm typo

### DIFF
--- a/docs/_book/plantuml/BuildingInfrastructure.puml
+++ b/docs/_book/plantuml/BuildingInfrastructure.puml
@@ -45,7 +45,7 @@ class Point <<geo>>
 class Polygon <<geo>>
 class Hemisphere <<hit2gap>>
 class Climate <<hit2gap>>
-class Northerm <<(I,orchid),hit2gap>>
+class Northern <<(I,orchid),hit2gap>>
 class Southern <<(I,orchid),hit2gap>>
 
 class Tropical <<(I,orchid),hit2gap>>
@@ -614,7 +614,7 @@ _Feature <|-- FeatureOfInterest
 _Feature <|-- System
 _Feature --> Hemisphere: hit2gap:locatedInHemisphere
 
-Hemisphere ..[#orchid] Northerm
+Hemisphere ..[#orchid] Northern
 Hemisphere ..[#orchid] Southern
 
 

--- a/docs/_book/plantuml/geo.puml
+++ b/docs/_book/plantuml/geo.puml
@@ -25,7 +25,7 @@ class _Geometry <<geo>>
 class Point <<geo>>
 class Polygon <<geo>>
 class Hemisphere <<hit2gap>>
-class Northerm <<(I,orchid),hit2gap>>
+class Northern <<(I,orchid),hit2gap>>
 class Southern <<(I,orchid),hit2gap>>
 
 
@@ -42,7 +42,7 @@ _Feature <|-- System
 
 _Feature --> Hemisphere: hit2gap:locatedInHemisphere
 
-Hemisphere ..[#orchid] Northerm
+Hemisphere ..[#orchid] Northern
 Hemisphere ..[#orchid] Southern
 
 

--- a/docs/plantuml/BuildingInfrastructure.puml
+++ b/docs/plantuml/BuildingInfrastructure.puml
@@ -45,7 +45,7 @@ class Point <<geo>>
 class Polygon <<geo>>
 class Hemisphere <<hit2gap>>
 class Climate <<hit2gap>>
-class Northerm <<(I,orchid),hit2gap>>
+class Northern <<(I,orchid),hit2gap>>
 class Southern <<(I,orchid),hit2gap>>
 
 class Tropical <<(I,orchid),hit2gap>>
@@ -614,7 +614,7 @@ _Feature <|-- FeatureOfInterest
 _Feature <|-- System
 _Feature --> Hemisphere: hit2gap:locatedInHemisphere
 
-Hemisphere ..[#orchid] Northerm
+Hemisphere ..[#orchid] Northern
 Hemisphere ..[#orchid] Southern
 
 

--- a/docs/plantuml/geo.puml
+++ b/docs/plantuml/geo.puml
@@ -25,7 +25,7 @@ class _Geometry <<geo>>
 class Point <<geo>>
 class Polygon <<geo>>
 class Hemisphere <<hit2gap>>
-class Northerm <<(I,orchid),hit2gap>>
+class Northern <<(I,orchid),hit2gap>>
 class Southern <<(I,orchid),hit2gap>>
 
 
@@ -42,7 +42,7 @@ _Feature <|-- System
 
 _Feature --> Hemisphere: hit2gap:locatedInHemisphere
 
-Hemisphere ..[#orchid] Northerm
+Hemisphere ..[#orchid] Northern
 Hemisphere ..[#orchid] Southern
 
 

--- a/owlModels/FullOntology.owl
+++ b/owlModels/FullOntology.owl
@@ -1043,10 +1043,10 @@ The features of interest representation of the building are performed using stan
         <NamedIndividual IRI="West"/>
     </Declaration>
     <Declaration>
-        <NamedIndividual IRI="http://hit2gap.eu/h2g/h2gSensor#Northerm"/>
+        <NamedIndividual IRI="http://hit2gap.eu/h2g/h2gSensor#Northern"/>
     </Declaration>
     <Declaration>
-        <NamedIndividual IRI="http://hit2gap.eu/h2g/h2gSensor#Southerm"/>
+        <NamedIndividual IRI="http://hit2gap.eu/h2g/h2gSensor#Southern"/>
     </Declaration>
     <Declaration>
         <NamedIndividual abbreviatedIRI="ifc4:SOLARCOLLECTOR"/>
@@ -2816,11 +2816,11 @@ The features of interest representation of the building are performed using stan
     </ClassAssertion>
     <ClassAssertion>
         <Class IRI="http://hit2gap.eu/h2g/h2gSensor#Hemisphere"/>
-        <NamedIndividual IRI="http://hit2gap.eu/h2g/h2gSensor#Northerm"/>
+        <NamedIndividual IRI="http://hit2gap.eu/h2g/h2gSensor#Northern"/>
     </ClassAssertion>
     <ClassAssertion>
         <Class IRI="http://hit2gap.eu/h2g/h2gSensor#Hemisphere"/>
-        <NamedIndividual IRI="http://hit2gap.eu/h2g/h2gSensor#Southerm"/>
+        <NamedIndividual IRI="http://hit2gap.eu/h2g/h2gSensor#Southern"/>
     </ClassAssertion>
     <ClassAssertion>
         <Class abbreviatedIRI="ifc4:IfcSolarDevice"/>
@@ -3688,8 +3688,8 @@ A feature is an abstraction of real world phenomena (thing, person, event, etc).
     </AnnotationAssertion>
     <AnnotationAssertion>
         <AnnotationProperty abbreviatedIRI="rdfs:isDefinedBy"/>
-        <IRI>http://hit2gap.eu/h2g/h2gSensor#Northerm</IRI>
-        <Literal xml:lang="en" datatypeIRI="&rdf;PlainLiteral">http://hit2gap.eu/h2g/h2gSensor#Northerm</Literal>
+        <IRI>http://hit2gap.eu/h2g/h2gSensor#Northern</IRI>
+        <Literal xml:lang="en" datatypeIRI="&rdf;PlainLiteral">http://hit2gap.eu/h2g/h2gSensor#Northern</Literal>
     </AnnotationAssertion>
     <AnnotationAssertion>
         <AnnotationProperty abbreviatedIRI="rdfs:comment"/>
@@ -3708,8 +3708,8 @@ A feature is an abstraction of real world phenomena (thing, person, event, etc).
     </AnnotationAssertion>
     <AnnotationAssertion>
         <AnnotationProperty abbreviatedIRI="rdfs:isDefinedBy"/>
-        <IRI>http://hit2gap.eu/h2g/h2gSensor#Southerm</IRI>
-        <Literal xml:lang="en" datatypeIRI="&rdf;PlainLiteral">http://hit2gap.eu/h2g/h2gSensor#Southerm</Literal>
+        <IRI>http://hit2gap.eu/h2g/h2gSensor#Southern</IRI>
+        <Literal xml:lang="en" datatypeIRI="&rdf;PlainLiteral">http://hit2gap.eu/h2g/h2gSensor#Southern</Literal>
     </AnnotationAssertion>
     <AnnotationAssertion>
         <AnnotationProperty abbreviatedIRI="rdfs:comment"/>

--- a/owlSpecificationDoc/BuildingInfraestructure/ontology.nt
+++ b/owlSpecificationDoc/BuildingInfraestructure/ontology.nt
@@ -2291,15 +2291,15 @@ _:genid64 <http://www.w3.org/2002/07/owl#allValuesFrom> <http://www.w3.org/ns/ss
 <http://hit2gap.eu/h2g/h2gBI#West> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#NamedIndividual> .
 <http://hit2gap.eu/h2g/h2gBI#West> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://hit2gap.eu/h2g/h2gBI#Orientation> .
 # 
-# http://hit2gap.eu/h2g/h2gSensor#Northerm
-<http://hit2gap.eu/h2g/h2gSensor#Northerm> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#NamedIndividual> .
-<http://hit2gap.eu/h2g/h2gSensor#Northerm> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://hit2gap.eu/h2g/h2gSensor#Hemisphere> .
-<http://hit2gap.eu/h2g/h2gSensor#Northerm> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> "http://hit2gap.eu/h2g/h2gSensor#Northerm"@en .
+# http://hit2gap.eu/h2g/h2gSensor#Northern
+<http://hit2gap.eu/h2g/h2gSensor#Northern> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#NamedIndividual> .
+<http://hit2gap.eu/h2g/h2gSensor#Northern> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://hit2gap.eu/h2g/h2gSensor#Hemisphere> .
+<http://hit2gap.eu/h2g/h2gSensor#Northern> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> "http://hit2gap.eu/h2g/h2gSensor#Northern"@en .
 # 
-# http://hit2gap.eu/h2g/h2gSensor#Southerm
-<http://hit2gap.eu/h2g/h2gSensor#Southerm> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#NamedIndividual> .
-<http://hit2gap.eu/h2g/h2gSensor#Southerm> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://hit2gap.eu/h2g/h2gSensor#Hemisphere> .
-<http://hit2gap.eu/h2g/h2gSensor#Southerm> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> "http://hit2gap.eu/h2g/h2gSensor#Southerm"@en .
+# http://hit2gap.eu/h2g/h2gSensor#Southern
+<http://hit2gap.eu/h2g/h2gSensor#Southern> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#NamedIndividual> .
+<http://hit2gap.eu/h2g/h2gSensor#Southern> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://hit2gap.eu/h2g/h2gSensor#Hemisphere> .
+<http://hit2gap.eu/h2g/h2gSensor#Southern> <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> "http://hit2gap.eu/h2g/h2gSensor#Southern"@en .
 # 
 # http://ifcowl.openbimstandards.org/IFC4_ADD2/index.html#SOLARCOLLECTOR
 <http://ifcowl.openbimstandards.org/IFC4_ADD2/index.html#SOLARCOLLECTOR> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#NamedIndividual> .

--- a/owlSpecificationDoc/BuildingInfraestructure/ontology.ttl
+++ b/owlSpecificationDoc/BuildingInfraestructure/ontology.ttl
@@ -2714,16 +2714,16 @@ Additional classifications of the IfcZone, as provided by a national classificat
                                             <http://hit2gap.eu/h2g/h2gBI#Orientation> .
 
 
-###  http://hit2gap.eu/h2g/h2gSensor#Northerm
-<http://hit2gap.eu/h2g/h2gSensor#Northerm> rdf:type owl:NamedIndividual ,
+###  http://hit2gap.eu/h2g/h2gSensor#Northern
+<http://hit2gap.eu/h2g/h2gSensor#Northern> rdf:type owl:NamedIndividual ,
                                                     <http://hit2gap.eu/h2g/h2gSensor#Hemisphere> ;
-                                           rdfs:isDefinedBy "http://hit2gap.eu/h2g/h2gSensor#Northerm"@en .
+                                           rdfs:isDefinedBy "http://hit2gap.eu/h2g/h2gSensor#Northern"@en .
 
 
-###  http://hit2gap.eu/h2g/h2gSensor#Southerm
-<http://hit2gap.eu/h2g/h2gSensor#Southerm> rdf:type owl:NamedIndividual ,
+###  http://hit2gap.eu/h2g/h2gSensor#Southern
+<http://hit2gap.eu/h2g/h2gSensor#Southern> rdf:type owl:NamedIndividual ,
                                                     <http://hit2gap.eu/h2g/h2gSensor#Hemisphere> ;
-                                           rdfs:isDefinedBy "http://hit2gap.eu/h2g/h2gSensor#Southerm"@en .
+                                           rdfs:isDefinedBy "http://hit2gap.eu/h2g/h2gSensor#Southern"@en .
 
 
 ###  http://ifcowl.openbimstandards.org/IFC4_ADD2/index.html#SOLARCOLLECTOR

--- a/owlSpecificationDoc/BuildingInfraestructure/ontology.xml
+++ b/owlSpecificationDoc/BuildingInfraestructure/ontology.xml
@@ -4167,22 +4167,22 @@ Additional classifications of the IfcZone, as provided by a national classificat
     
 
 
-    <!-- http://hit2gap.eu/h2g/h2gSensor#Northerm -->
+    <!-- http://hit2gap.eu/h2g/h2gSensor#Northern -->
 
 
-    <owl:NamedIndividual rdf:about="http://hit2gap.eu/h2g/h2gSensor#Northerm">
+    <owl:NamedIndividual rdf:about="http://hit2gap.eu/h2g/h2gSensor#Northern">
         <rdf:type rdf:resource="http://hit2gap.eu/h2g/h2gSensor#Hemisphere"/>
-        <rdfs:isDefinedBy xml:lang="en">http://hit2gap.eu/h2g/h2gSensor#Northerm</rdfs:isDefinedBy>
+        <rdfs:isDefinedBy xml:lang="en">http://hit2gap.eu/h2g/h2gSensor#Northern</rdfs:isDefinedBy>
     </owl:NamedIndividual>
     
 
 
-    <!-- http://hit2gap.eu/h2g/h2gSensor#Southerm -->
+    <!-- http://hit2gap.eu/h2g/h2gSensor#Southern -->
 
 
-    <owl:NamedIndividual rdf:about="http://hit2gap.eu/h2g/h2gSensor#Southerm">
+    <owl:NamedIndividual rdf:about="http://hit2gap.eu/h2g/h2gSensor#Southern">
         <rdf:type rdf:resource="http://hit2gap.eu/h2g/h2gSensor#Hemisphere"/>
-        <rdfs:isDefinedBy xml:lang="en">http://hit2gap.eu/h2g/h2gSensor#Southerm</rdfs:isDefinedBy>
+        <rdfs:isDefinedBy xml:lang="en">http://hit2gap.eu/h2g/h2gSensor#Southern</rdfs:isDefinedBy>
     </owl:NamedIndividual>
     
 

--- a/owlSpecificationDoc/BuildingInfraestructure/sections/crossref-en.html
+++ b/owlSpecificationDoc/BuildingInfraestructure/sections/crossref-en.html
@@ -2116,8 +2116,8 @@ Geothermal resources are reservoirs of hot water that exist at varying temperatu
       <dl class="description">
          <dt>has members</dt>
          <dd>
-            <a href="#http://hit2gap.eu/h2g/h2gSensor#Northerm" title="http://hit2gap.eu/h2g/h2gSensor#Northerm">northerm</a>
-            <sup class="type-ni" title="named individual">ni</sup>, <a href="#http://hit2gap.eu/h2g/h2gSensor#Southerm" title="http://hit2gap.eu/h2g/h2gSensor#Southerm">southerm</a>
+            <a href="#http://hit2gap.eu/h2g/h2gSensor#Northern" title="http://hit2gap.eu/h2g/h2gSensor#Northern">northern</a>
+            <sup class="type-ni" title="named individual">ni</sup>, <a href="#http://hit2gap.eu/h2g/h2gSensor#Southern" title="http://hit2gap.eu/h2g/h2gSensor#Southern">southern</a>
             <sup class="type-ni" title="named individual">ni</sup>
          </dd>
       </dl>
@@ -8056,8 +8056,8 @@ Q = nU.</span>
          </a>
       </li>
       <li>
-         <a href="#http://hit2gap.eu/h2g/h2gSensor#Northerm" title="http://hit2gap.eu/h2g/h2gSensor#Northerm">
-            <span>northerm</span>
+         <a href="#http://hit2gap.eu/h2g/h2gSensor#Northern" title="http://hit2gap.eu/h2g/h2gSensor#Northern">
+            <span>northern</span>
          </a>
       </li>
       <li>
@@ -8155,8 +8155,8 @@ Q = nU.</span>
          </a>
       </li>
       <li>
-         <a href="#http://hit2gap.eu/h2g/h2gSensor#Southerm" title="http://hit2gap.eu/h2g/h2gSensor#Southerm">
-            <span>southerm</span>
+         <a href="#http://hit2gap.eu/h2g/h2gSensor#Southern" title="http://hit2gap.eu/h2g/h2gSensor#Southern">
+            <span>southern</span>
          </a>
       </li>
       <li>
@@ -8665,13 +8665,13 @@ Q = nU.</span>
          </dd>
       </dl>
    </div>
-   <div class="entity" id="http://hit2gap.eu/h2g/h2gSensor#Northerm">
-      <h3>northerm<sup class="type-ni" title="named individual">ni</sup>
+   <div class="entity" id="http://hit2gap.eu/h2g/h2gSensor#Northern">
+      <h3>northern<sup class="type-ni" title="named individual">ni</sup>
          <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#namedindividuals">Named Individual ToC</a>
          </span>
       </h3>
       <p>
-         <strong>IRI:</strong> http://hit2gap.eu/h2g/h2gSensor#Northerm</p>
+         <strong>IRI:</strong> http://hit2gap.eu/h2g/h2gSensor#Northern</p>
       <dl class="definedBy">
          <dt>Is defined by</dt>
          <dd>http://hit2gap.eu/h2g/h2gBI#</dd>
@@ -8978,13 +8978,13 @@ Q = nU.</span>
          </dd>
       </dl>
    </div>
-   <div class="entity" id="http://hit2gap.eu/h2g/h2gSensor#Southerm">
-      <h3>southerm<sup class="type-ni" title="named individual">ni</sup>
+   <div class="entity" id="http://hit2gap.eu/h2g/h2gSensor#Southern">
+      <h3>southern<sup class="type-ni" title="named individual">ni</sup>
          <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#namedindividuals">Named Individual ToC</a>
          </span>
       </h3>
       <p>
-         <strong>IRI:</strong> http://hit2gap.eu/h2g/h2gSensor#Southerm</p>
+         <strong>IRI:</strong> http://hit2gap.eu/h2g/h2gSensor#Southern</p>
       <dl class="definedBy">
          <dt>Is defined by</dt>
          <dd>http://hit2gap.eu/h2g/h2gBI#</dd>

--- a/owlSpecificationDoc/BuildingInfraestructure/sections/overview-en.html
+++ b/owlSpecificationDoc/BuildingInfraestructure/sections/overview-en.html
@@ -1096,8 +1096,8 @@ This ontology has the following classes and properties.</span>
       </a>
    </li>
    <li>
-      <a href="#http://hit2gap.eu/h2g/h2gSensor#Northerm" title="http://hit2gap.eu/h2g/h2gSensor#Northerm">
-         <span>northerm</span>
+      <a href="#http://hit2gap.eu/h2g/h2gSensor#Northern" title="http://hit2gap.eu/h2g/h2gSensor#Northern">
+         <span>northern</span>
       </a>
    </li>
    <li>
@@ -1195,8 +1195,8 @@ This ontology has the following classes and properties.</span>
       </a>
    </li>
    <li>
-      <a href="#http://hit2gap.eu/h2g/h2gSensor#Southerm" title="http://hit2gap.eu/h2g/h2gSensor#Southerm">
-         <span>southerm</span>
+      <a href="#http://hit2gap.eu/h2g/h2gSensor#Southern" title="http://hit2gap.eu/h2g/h2gSensor#Southern">
+         <span>southern</span>
       </a>
    </li>
    <li>

--- a/owlSpecificationDoc/SensorRepresentation/ontology.nt
+++ b/owlSpecificationDoc/SensorRepresentation/ontology.nt
@@ -242,9 +242,9 @@ _:genid17 <http://www.w3.org/2002/07/owl#allValuesFrom> <http://data.qudt.org/qu
 # #################################################################
 # 
 # 
-# http://hit2gap.eu/h2g/h2gSensor#Northerm
-<http://hit2gap.eu/h2g/h2gSensor#Northerm> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#NamedIndividual> .
-<http://hit2gap.eu/h2g/h2gSensor#Northerm> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://hit2gap.eu/h2g/h2gSensor#Hemisphere> .
+# http://hit2gap.eu/h2g/h2gSensor#Northern
+<http://hit2gap.eu/h2g/h2gSensor#Northern> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#NamedIndividual> .
+<http://hit2gap.eu/h2g/h2gSensor#Northern> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://hit2gap.eu/h2g/h2gSensor#Hemisphere> .
 # 
 # http://hit2gap.eu/h2g/h2gSensor#Southern
 <http://hit2gap.eu/h2g/h2gSensor#Southern> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#NamedIndividual> .

--- a/owlSpecificationDoc/SensorRepresentation/ontology.ttl
+++ b/owlSpecificationDoc/SensorRepresentation/ontology.ttl
@@ -249,8 +249,8 @@ Q = nU."""@en ;
 #    Individuals
 #################################################################
 
-###  http://hit2gap.eu/h2g/h2gSensor#Northerm
-<http://hit2gap.eu/h2g/h2gSensor#Northerm> rdf:type owl:NamedIndividual ,
+###  http://hit2gap.eu/h2g/h2gSensor#Northern
+<http://hit2gap.eu/h2g/h2gSensor#Northern> rdf:type owl:NamedIndividual ,
                                                     <http://hit2gap.eu/h2g/h2gSensor#Hemisphere> .
 
 

--- a/owlSpecificationDoc/SensorRepresentation/ontology.xml
+++ b/owlSpecificationDoc/SensorRepresentation/ontology.xml
@@ -439,10 +439,10 @@ Q = nU.</rdfs:comment>
     
 
 
-    <!-- http://hit2gap.eu/h2g/h2gSensor#Northerm -->
+    <!-- http://hit2gap.eu/h2g/h2gSensor#Northern -->
 
 
-    <owl:NamedIndividual rdf:about="http://hit2gap.eu/h2g/h2gSensor#Northerm">
+    <owl:NamedIndividual rdf:about="http://hit2gap.eu/h2g/h2gSensor#Northern">
         <rdf:type rdf:resource="http://hit2gap.eu/h2g/h2gSensor#Hemisphere"/>
     </owl:NamedIndividual>
     

--- a/owlSpecificationDoc/SensorRepresentation/sections/crossref-en.html
+++ b/owlSpecificationDoc/SensorRepresentation/sections/crossref-en.html
@@ -164,7 +164,7 @@ This section provides details for each class and property defined by Hit2Gap Ont
       <dl class="description">
          <dt>has members</dt>
          <dd>
-            <a href="#Northerm" title="http://hit2gap.eu/h2g/h2gSensor#Northerm">northerm</a>
+            <a href="#Northern" title="http://hit2gap.eu/h2g/h2gSensor#Northern">northern</a>
             <sup class="type-ni" title="named individual">ni</sup>, <a href="#Southern" title="http://hit2gap.eu/h2g/h2gSensor#Southern">southern</a>
             <sup class="type-ni" title="named individual">ni</sup>
          </dd>
@@ -428,8 +428,8 @@ Q = nU.</span>
    <h3 id="namedindividuals" class="list">Named Individuals</h3>
    <ul class="hlist">
       <li>
-         <a href="#Northerm" title="http://hit2gap.eu/h2g/h2gSensor#Northerm">
-            <span>northerm</span>
+         <a href="#Northern" title="http://hit2gap.eu/h2g/h2gSensor#Northern">
+            <span>northern</span>
          </a>
       </li>
       <li>
@@ -438,13 +438,13 @@ Q = nU.</span>
          </a>
       </li>
    </ul>
-   <div class="entity" id="Northerm">
-      <h3>northerm<sup class="type-ni" title="named individual">ni</sup>
+   <div class="entity" id="Northern">
+      <h3>northern<sup class="type-ni" title="named individual">ni</sup>
          <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#namedindividuals">Named Individual ToC</a>
          </span>
       </h3>
       <p>
-         <strong>IRI:</strong> http://hit2gap.eu/h2g/h2gSensor#Northerm</p>
+         <strong>IRI:</strong> http://hit2gap.eu/h2g/h2gSensor#Northern</p>
       <dl class="description">
          <dt>belongs to</dt>
          <dd>

--- a/owlSpecificationDoc/SensorRepresentation/sections/overview-en.html
+++ b/owlSpecificationDoc/SensorRepresentation/sections/overview-en.html
@@ -70,8 +70,8 @@ This ontology has the following classes and properties.</span>
    </li>
 </ul><h4>Named Individuals</h4><ul class="hlist">
    <li>
-      <a href="#Northerm" title="http://hit2gap.eu/h2g/h2gSensor#Northerm">
-         <span>northerm</span>
+      <a href="#Northern" title="http://hit2gap.eu/h2g/h2gSensor#Northern">
+         <span>northern</span>
       </a>
    </li>
    <li>


### PR DESCRIPTION
This was fixed in some places by @ycardinale in https://github.com/HIT2GAP-EU-PROJECT/HIT2GAPOnt/commit/5a3d6620028e3f4172794208852a4e7ed5654817.

Any reason not to fix it everywhere?